### PR TITLE
Improve BTC price display

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 This project hosts a small web page that lists companies with Bitcoin treasuries.
 The data is loaded dynamically from the [data-btc-treasuries.com](https://github.com/baxter2/data-btc-treasuries.com) repository so the table is kept current.
 Simply open `docs/index.html` in a browser to see the latest tickers and transaction dates.
+The page now also shows the current Bitcoin price fetched directly from CoinGecko and displays it prominently on the home page.

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,7 @@
   <header>
     <img class="logo" src="https://cryptologos.cc/logos/bitcoin-btc-logo.png" alt="BTC">
     <h1>Fresh BTC Treasury Tickers</h1>
+    <p id="price" class="price">loading price…</p>
     <p id="stamp">loading…</p>
     <button id="reload">↻ refresh</button>
   </header>

--- a/docs/script.js
+++ b/docs/script.js
@@ -4,6 +4,8 @@ const proxies=[u=>`https://api.allorigins.win/raw?url=${encodeURIComponent(u)}`,
                u=>`https://proxy.cors.sh/${u}`];
 const tbody=document.getElementById('tbody');
 const stamp=document.getElementById('stamp');
+const priceEl=document.getElementById('price');
+const priceSrc='https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd';
 document.getElementById('reload').onclick=load;
 load(); setInterval(load,3600e3);
 
@@ -15,6 +17,13 @@ async function fetchHTML(url){
     }catch(_){}
   }
   throw Error('all proxies failed');
+}
+
+async function fetchPrice(){
+  const r=await fetch(priceSrc);
+  if(!r.ok) throw Error('price fetch failed');
+  const json=await r.json();
+  return json.bitcoin.usd;
 }
 function parse(html){
   const doc=new DOMParser().parseFromString(html,'text/html');
@@ -42,6 +51,8 @@ function render(rows){
 async function load(){
   stamp.textContent='updating…';
   try{
+    const price=await fetchPrice();
+    priceEl.textContent='$'+price.toLocaleString();
     const html=await fetchHTML(sources[0]);
     render(parse(html));
     stamp.textContent='last update '+new Date().toLocaleString();

--- a/docs/style.css
+++ b/docs/style.css
@@ -6,6 +6,7 @@ nav a{color:var(--fg);text-decoration:none}
 nav a.logo{font-weight:700;color:var(--orange)}
 header{text-align:center;padding:40px 10px}
 h1{color:var(--orange);font-size:2rem;margin-bottom:6px}
+#price{font-size:4rem;margin:10px 0;font-weight:700}
 #stamp{font-size:.85rem;color:#aaa;margin-bottom:10px}
 button{border:1px solid var(--orange);background:none;color:var(--orange);padding:6px 18px;cursor:pointer}
 main{padding:0 10px 40px}


### PR DESCRIPTION
## Summary
- fetch Bitcoin price directly from CoinGecko
- enlarge the price text size
- note new price behaviour in README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_685ef9347b54833389c8105d723da4a4