### PR TITLE
Add resume and dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Sam Carter Portfolio
 
 This repository contains a minimalist static portfolio website for **Sam Carter**.
-Open `docs/index.html` in your browser to view the site. The design now
-features a dark theme, custom fonts, and a small typewriter effect on the hero
-section.
+Open `docs/index.html` in your browser to view the site. The design includes
+a dark theme and simple pages for About, Projects, and a short Resume.

--- a/docs/about.html
+++ b/docs/about.html
@@ -9,9 +9,13 @@
 <body>
   <nav>
     <a class="logo" href="index.html">Sam Carter</a>
+    <a href="about.html">About</a>
+    <a href="projects.html">Projects</a>
+    <a href="resume.html">Resume</a>
   </nav>
   <main>
     <p>Sam Carter is a lab technician and robotics instructor from Carlsbad, California.</p>
+    <p>He builds custom 3D printers and mentors local students in competitive robotics.</p>
   </main>
   <footer>© 2025 Sam Carter</footer>
 </body>

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -9,6 +9,9 @@
 <body>
   <nav>
     <a class="logo" href="index.html">Sam Carter</a>
+    <a href="about.html">About</a>
+    <a href="projects.html">Projects</a>
+    <a href="resume.html">Resume</a>
   </nav>
   <main>
     <ul>

--- a/docs/resume.html
+++ b/docs/resume.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Sam Carter</title>
+  <title>Resume • Sam Carter</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -13,12 +13,18 @@
     <a href="projects.html">Projects</a>
     <a href="resume.html">Resume</a>
   </nav>
-  <header>
-    <h1>Sam Carter</h1>
-  </header>
   <main>
-    <p>Lab tech and robotics instructor.</p>
-    <p>Specializes in 3D printing and hands-on STEM education.</p>
+    <section>
+      <h2>Experience</h2>
+      <ul>
+        <li>3D Printing Technician, GKN Additive</li>
+        <li>Robotics Instructor, CEF</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Education</h2>
+      <p>B.S. Mechanical Engineering, UC San Diego</p>
+    </section>
   </main>
   <footer>© 2025 Sam Carter</footer>
 </body>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,15 +1,15 @@
 body {
   margin: 2rem;
   font-family: sans-serif;
-  background: #fff;
-  color: #000;
+  background: #222;
+  color: #eee;
 }
 nav {
   margin-bottom: 2rem;
 }
 nav a {
   margin-right: 1rem;
-  color: #000;
+  color: #eee;
   text-decoration: none;
 }
 nav a.logo {


### PR DESCRIPTION
## Summary
- use a dark gray theme
- link to a new Resume page
- add a short resume with experience and education
- mention the resume in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687972240ed88333a8c8486383d35b1f