### PR TITLE
Improve Rubik's Cube demo and restore site pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Bitcoin Price Viewer
+# Portfolio and Demos
 
-This repository contains a single-page website that displays the Bitcoin price chart using the TradingView widget.
+This site includes a simple portfolio with an interactive Rubik's Cube, a Bitcoin price viewer, and placeholder pages for future content.
 
-Open `docs/index.html` in your browser to view the chart. The page fills the entire screen and works on both desktop and mobile devices.
+Open `docs/index.html` to try the cube and explore the navigation links. The original Bitcoin chart is now available at `docs/bitcoin.html`.

--- a/docs/about.html
+++ b/docs/about.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>About • Sam Carter</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a class="logo" href="index.html">Sam Carter</a>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="projects.html">Projects</a>
+    <a href="resume.html">Resume</a>
+    <a href="bitcoin.html">Bitcoin</a>
+  </nav>
+
+  <header class="hero">
+    <h1>About Me</h1>
+  </header>
+
+  <main>
+    <div class="split">
+      <div>
+        <p>Hi, I'm Sam Carter, a lab technician and robotics instructor from
+        Carlsbad, California. At GKN Additive I managed SLA, PolyJet, and FDM
+        printers for custom manufacturing.</p>
+        <p>I've coordinated robotics programs with the Carlsbad Educational
+        Foundation and mentored dozens of student teams. Outside the lab I enjoy
+        hiking and supporting community STEM outreach.</p>
+      </div>
+      <div class="avatar"></div>
+    </div>
+  </main>
+
+  <footer>
+    © 2025 Sam Carter — more info coming soon
+  </footer>
+</body>
+</html>

--- a/docs/bitcoin.html
+++ b/docs/bitcoin.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Bitcoin Price</title>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+    }
+    .tradingview-widget-container {
+      height: 100%;
+    }
+    #tv_chart {
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div class="tradingview-widget-container">
+    <div id="tv_chart"></div>
+  </div>
+  <script src="https://s3.tradingview.com/tv.js"></script>
+  <script>
+    new TradingView.widget({
+      "container_id": "tv_chart",
+      "symbol": "BITSTAMP:BTCUSD",
+      "interval": "D",
+      "theme": "dark",
+      "style": "1",
+      "locale": "en",
+      "timezone": "Etc/UTC",
+      "width": "100%",
+      "height": "100%",
+      "hide_top_toolbar": true,
+      "withdateranges": true
+    });
+  </script>
+</body>
+</html>

--- a/docs/cube.css
+++ b/docs/cube.css
@@ -1,0 +1,50 @@
+#scene {
+  perspective: 800px;
+  width: 240px;
+  height: 240px;
+  margin: 2rem auto;
+  user-select: none;
+}
+
+#cube {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  margin: auto;
+  transform-style: preserve-3d;
+  transform: rotateX(-30deg) rotateY(45deg);
+  transition: transform 0.3s ease;
+  cursor: grab;
+}
+
+.face {
+  position: absolute;
+  width: 120px;
+  height: 120px;
+  display: grid;
+  grid-template-columns: repeat(3, 40px);
+  grid-template-rows: repeat(3, 40px);
+  gap: 2px;
+  transition: transform 0.3s;
+  backface-visibility: hidden;
+}
+
+.tile {
+  width: 40px;
+  height: 40px;
+  border: 1px solid #333;
+  backface-visibility: hidden;
+}
+
+#F { transform: translateZ(60px); }
+#B { transform: rotateY(180deg) translateZ(60px); }
+#U { transform: rotateX(90deg) translateZ(60px); }
+#D { transform: rotateX(-90deg) translateZ(60px); }
+#L { transform: rotateY(-90deg) translateZ(60px); }
+#R { transform: rotateY(90deg) translateZ(60px); }
+
+.controls { text-align: center; margin-bottom: 1rem; }
+
+#cube.dragging {
+  cursor: grabbing;
+}

--- a/docs/cube.js
+++ b/docs/cube.js
@@ -1,0 +1,282 @@
+const colors = {
+  U: 'white',
+  D: 'yellow',
+  F: 'green',
+  B: 'blue',
+  L: 'orange',
+  R: 'red'
+};
+
+const cube = {
+  U: Array(9).fill(colors.U),
+  D: Array(9).fill(colors.D),
+  F: Array(9).fill(colors.F),
+  B: Array(9).fill(colors.B),
+  L: Array(9).fill(colors.L),
+  R: Array(9).fill(colors.R)
+};
+
+function rotateFaceCW(face) {
+  const [a,b,c,d,e,f,g,h,i] = cube[face];
+  cube[face][0] = g;
+  cube[face][1] = d;
+  cube[face][2] = a;
+  cube[face][3] = h;
+  cube[face][4] = e;
+  cube[face][5] = b;
+  cube[face][6] = i;
+  cube[face][7] = f;
+  cube[face][8] = c;
+}
+
+function rotateU() {
+  rotateFaceCW('U');
+  const tmp = cube.F.slice(0,3);
+  cube.F[0] = cube.R[0]; cube.F[1] = cube.R[1]; cube.F[2] = cube.R[2];
+  cube.R[0] = cube.B[0]; cube.R[1] = cube.B[1]; cube.R[2] = cube.B[2];
+  cube.B[0] = cube.L[0]; cube.B[1] = cube.L[1]; cube.B[2] = cube.L[2];
+  cube.L[0] = tmp[0]; cube.L[1] = tmp[1]; cube.L[2] = tmp[2];
+}
+
+function rotateD() {
+  rotateFaceCW('D');
+  const tmp = cube.F.slice(6,9);
+  cube.F[6] = cube.L[6]; cube.F[7] = cube.L[7]; cube.F[8] = cube.L[8];
+  cube.L[6] = cube.B[6]; cube.L[7] = cube.B[7]; cube.L[8] = cube.B[8];
+  cube.B[6] = cube.R[6]; cube.B[7] = cube.R[7]; cube.B[8] = cube.R[8];
+  cube.R[6] = tmp[0]; cube.R[7] = tmp[1]; cube.R[8] = tmp[2];
+}
+
+function rotateF() {
+  rotateFaceCW('F');
+  const t0 = cube.U[6], t1 = cube.U[7], t2 = cube.U[8];
+  cube.U[6] = cube.L[8]; cube.U[7] = cube.L[5]; cube.U[8] = cube.L[2];
+  cube.L[8] = cube.D[2]; cube.L[5] = cube.D[1]; cube.L[2] = cube.D[0];
+  cube.D[2] = cube.R[0]; cube.D[1] = cube.R[3]; cube.D[0] = cube.R[6];
+  cube.R[0] = t0; cube.R[3] = t1; cube.R[6] = t2;
+}
+
+function rotateB() {
+  rotateFaceCW('B');
+  const t0 = cube.U[0], t1 = cube.U[1], t2 = cube.U[2];
+  cube.U[0] = cube.R[2]; cube.U[1] = cube.R[5]; cube.U[2] = cube.R[8];
+  cube.R[2] = cube.D[8]; cube.R[5] = cube.D[7]; cube.R[8] = cube.D[6];
+  cube.D[8] = cube.L[6]; cube.D[7] = cube.L[3]; cube.D[6] = cube.L[0];
+  cube.L[6] = t0; cube.L[3] = t1; cube.L[0] = t2;
+}
+
+function rotateL() {
+  rotateFaceCW('L');
+  const t0 = cube.U[0], t1 = cube.U[3], t2 = cube.U[6];
+  cube.U[0] = cube.F[0]; cube.U[3] = cube.F[3]; cube.U[6] = cube.F[6];
+  cube.F[0] = cube.D[0]; cube.F[3] = cube.D[3]; cube.F[6] = cube.D[6];
+  cube.D[0] = cube.B[8]; cube.D[3] = cube.B[5]; cube.D[6] = cube.B[2];
+  cube.B[8] = t0; cube.B[5] = t1; cube.B[2] = t2;
+}
+
+function rotateR() {
+  rotateFaceCW('R');
+  const t0 = cube.U[2], t1 = cube.U[5], t2 = cube.U[8];
+  cube.U[2] = cube.B[6]; cube.U[5] = cube.B[3]; cube.U[8] = cube.B[0];
+  cube.B[6] = cube.D[8]; cube.B[3] = cube.D[5]; cube.B[0] = cube.D[2];
+  cube.D[8] = cube.F[8]; cube.D[5] = cube.F[5]; cube.D[2] = cube.F[2];
+  cube.F[8] = t0; cube.F[5] = t1; cube.F[2] = t2;
+}
+
+const rotateFuncs = { U: rotateU, D: rotateD, F: rotateF, B: rotateB, L: rotateL, R: rotateR };
+
+function updateDisplay() {
+  for (const face of ['U','D','F','B','L','R']) {
+    for (let i=0;i<9;i++) {
+      document.querySelector(`#${face} .t${i}`).style.background = cube[face][i];
+    }
+  }
+}
+
+function runNextMove() {
+  if (moveQueue.length === 0) { animating = false; return; }
+  animating = true;
+  const {face, inverse} = moveQueue.shift();
+  const fn = rotateFuncs[face];
+  const exec = () => {
+    if (inverse) { for (let i=0;i<3;i++) fn(); }
+    else fn();
+  };
+  animateAndRotate(face, exec, runNextMove);
+}
+
+function queueMove(face, inverse=false) {
+  moveQueue.push({face, inverse});
+  if (!animating) runNextMove();
+}
+
+function scramble() {
+  const moves = ['U','D','F','B','L','R'];
+  for (let i=0;i<20;i++) {
+    const face = moves[Math.floor(Math.random()*moves.length)];
+    queueMove(face);
+  }
+}
+
+function resetCube() {
+  cube.U.fill(colors.U);
+  cube.D.fill(colors.D);
+  cube.F.fill(colors.F);
+  cube.B.fill(colors.B);
+  cube.L.fill(colors.L);
+  cube.R.fill(colors.R);
+  moveQueue = [];
+  animating = false;
+  updateDisplay();
+}
+
+function setup() {
+  const container = document.getElementById('cube');
+  ['U','L','F','R','B','D'].forEach(face => {
+    const f = document.createElement('div');
+    f.id = face;
+    f.className = 'face';
+    for(let i=0;i<9;i++) {
+      const sq = document.createElement('div');
+      sq.className = `tile t${i}`;
+      f.appendChild(sq);
+    }
+    container.appendChild(f);
+  });
+  updateDisplay();
+}
+
+const faceTransforms = {
+  U: 'rotateX(90deg) translateZ(60px)',
+  D: 'rotateX(-90deg) translateZ(60px)',
+  F: 'translateZ(60px)',
+  B: 'rotateY(180deg) translateZ(60px)',
+  L: 'rotateY(-90deg) translateZ(60px)',
+  R: 'rotateY(90deg) translateZ(60px)'
+};
+
+const faceAxis = { U: 'Y', D: 'Y', F: 'Z', B: 'Z', L: 'X', R: 'X' };
+
+let rotX = -30;
+let rotY = 45;
+let dragging = false;
+let startX, startY;
+
+let moveQueue = [];
+let animating = false;
+let faceDrag = null;
+let faceStartX = 0;
+
+function updateCubeRotation() {
+  const cubeEl = document.getElementById('cube');
+  cubeEl.style.transform = `rotateX(${rotX}deg) rotateY(${rotY}deg)`;
+}
+
+function initMouseControls() {
+  const scene = document.getElementById('scene');
+  const cubeEl = document.getElementById('cube');
+
+  scene.addEventListener('mousedown', e => {
+    dragging = true;
+    startX = e.clientX;
+    startY = e.clientY;
+    cubeEl.classList.add('dragging');
+  });
+
+  document.querySelectorAll('.face').forEach(f => {
+    f.addEventListener('mousedown', e => {
+      faceDrag = f.id;
+      faceStartX = e.clientX;
+      e.stopPropagation();
+    });
+  });
+
+  document.addEventListener('mousemove', e => {
+    if (!dragging) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    rotY += dx * 0.4;
+    rotX -= dy * 0.4;
+    updateCubeRotation();
+    startX = e.clientX;
+    startY = e.clientY;
+  });
+
+  document.addEventListener('mouseup', e => {
+    dragging = false;
+    cubeEl.classList.remove('dragging');
+    if (faceDrag) {
+      const dx = e.clientX - faceStartX;
+      if (dx > 30) queueMove(faceDrag);
+      else if (dx < -30) queueMove(faceDrag, true);
+      faceDrag = null;
+    }
+  });
+
+  scene.addEventListener('touchstart', e => {
+    dragging = true;
+    startX = e.touches[0].clientX;
+    startY = e.touches[0].clientY;
+  });
+
+  document.querySelectorAll('.face').forEach(f => {
+    f.addEventListener('touchstart', e => {
+      faceDrag = f.id;
+      faceStartX = e.touches[0].clientX;
+      e.stopPropagation();
+    });
+  });
+
+  scene.addEventListener('touchmove', e => {
+    if (!dragging) return;
+    const dx = e.touches[0].clientX - startX;
+    const dy = e.touches[0].clientY - startY;
+    rotY += dx * 0.4;
+    rotX -= dy * 0.4;
+    updateCubeRotation();
+    startX = e.touches[0].clientX;
+    startY = e.touches[0].clientY;
+  });
+
+  document.addEventListener('touchend', e => {
+    dragging = false;
+    if (faceDrag) {
+      const dx = e.changedTouches[0].clientX - faceStartX;
+      if (dx > 30) queueMove(faceDrag);
+      else if (dx < -30) queueMove(faceDrag, true);
+      faceDrag = null;
+    }
+  });
+
+  updateCubeRotation();
+}
+
+function animateAndRotate(face, fn, cb) {
+  const el = document.getElementById(face);
+  const axis = faceAxis[face];
+  el.style.transition = 'transform 0.3s';
+  el.style.transform = faceTransforms[face] + ` rotate${axis}(90deg)`;
+  setTimeout(() => {
+    fn();
+    updateDisplay();
+    el.style.transition = '';
+    el.style.transform = faceTransforms[face];
+    if (cb) cb();
+  }, 300);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setup();
+  initMouseControls();
+});
+document.addEventListener('keydown', e => {
+  switch(e.key.toUpperCase()) {
+    case 'U': return queueMove('U');
+    case 'D': return queueMove('D');
+    case 'F': return queueMove('F');
+    case 'B': return queueMove('B');
+    case 'L': return queueMove('L');
+    case 'R': return queueMove('R');
+    default: return;
+  }
+});

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Projects • Sam Carter</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a class="logo" href="index.html">Sam Carter</a>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="projects.html">Projects</a>
+    <a href="resume.html">Resume</a>
+    <a href="bitcoin.html">Bitcoin</a>
+  </nav>
+
+  <header class="hero">
+    <h1>Projects</h1>
+  </header>
+
+  <main>
+    <div class="projects">
+      <div class="card">
+        <h2>3D Printing Operations</h2>
+        <p>Oversaw SLA, PolyJet, and FDM printers at GKN Additive to produce custom
+        parts and prototypes.</p>
+      </div>
+      <div class="card">
+        <h2>Robotics Mentorship</h2>
+        <p>Developed curriculum and mentored more than 50 middle school teams
+        through the Carlsbad Educational Foundation.</p>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    © 2025 Sam Carter — projects coming soon
+  </footer>
+</body>
+</html>

--- a/docs/resume.html
+++ b/docs/resume.html
@@ -3,9 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Sam Carter</title>
+  <title>Resume • Sam Carter</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="cube.css">
 </head>
 <body>
   <nav>
@@ -15,18 +14,20 @@
     <a href="resume.html">Resume</a>
     <a href="bitcoin.html">Bitcoin</a>
   </nav>
-  <header>
-    <h1>Sam Carter</h1>
-    <h2 id="typewriter"></h2>
-  </header>
   <main>
-    <p>Lab tech and robotics instructor.</p>
-    <p>Specializes in 3D printing and hands-on STEM education.</p>
-    <p>Currently exploring <strong>AI</strong> research at <strong>MiraCosta College</strong>.</p>
-    <div id="scene"><div id="cube"></div></div>
+    <section>
+      <h2>Experience</h2>
+      <ul>
+        <li>3D Printing Technician, GKN Additive</li>
+        <li>Robotics Instructor, CEF</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Education</h2>
+      <p>B.S. Mechanical Engineering, UC San Diego</p>
+    </section>
   </main>
   <footer>© 2025 Sam Carter</footer>
-  <script src="typewriter.js"></script>
-  <script src="cube.js"></script>
+  <p style="text-align:center;color:#bbb;">Full resume coming soon.</p>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,199 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500&family=Space+Grotesk:wght@400;700;900&display=swap');
+
+@keyframes gradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  --primary: #1a1a2e;
+  --navy: #16213e;
+  --accent: #f472b6;
+  --accent2: #60a5fa;
+}
+
+body {
+  margin: 0;
+  font-family: 'IBM Plex Sans', sans-serif;
+  line-height: 1.6;
+  background: linear-gradient(45deg, #1e3a8a, #9333ea, #ec4899, #14b8a6);
+  background-size: 400% 400%;
+  color: #eee;
+  animation: gradient 20s ease infinite;
+  font-size: 1.2rem;
+}
+
+nav {
+  background: linear-gradient(90deg, var(--navy), var(--primary));
+  color: #fff;
+  padding: 1rem;
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+  position: relative;
+}
+
+nav a::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--accent2);
+  transition: width 0.3s ease;
+}
+
+nav a:hover::after {
+  width: 100%;
+}
+
+nav a.logo {
+  font-weight: 900;
+  margin-right: auto;
+}
+
+header {
+  text-align: center;
+  padding: 4rem 1rem;
+}
+
+p {
+  font-size: 1.1em;
+}
+
+h1 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 3rem;
+  margin: 0 0 0.5rem 0;
+  font-weight: 900;
+}
+
+h2 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 700;
+}
+
+.avatar {
+  width: 120px;
+  height: 120px;
+  margin: 0 auto 1.5rem auto;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  transition: transform 0.6s ease;
+}
+
+.avatar:hover {
+  transform: rotate(20deg) scale(1.05);
+}
+
+.split {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: center;
+}
+
+.split .avatar {
+  flex: 0 0 150px;
+}
+
+.badges {
+  display: flex;
+  overflow-x: auto;
+  gap: 0.5rem;
+  padding: 1rem 0;
+}
+
+.badge {
+  white-space: nowrap;
+  padding: 0.3rem 0.8rem;
+  border-radius: 9999px;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  font-size: 0.9rem;
+}
+
+.projects {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: rgba(255,255,255,0.05);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 15px rgba(0,0,0,0.3);
+}
+
+main {
+  max-width: 900px;
+  margin: auto;
+  padding: 1rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+.hero .typewriter {
+  color: var(--accent);
+  min-height: 2.2rem;
+  font-weight: 300;
+}
+
+.cursor {
+  display: inline-block;
+  width: 2px;
+  background: var(--accent);
+  margin-left: 2px;
+  animation: blink 1s infinite;
+}
+
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+.buttons {
+  margin-top: 1.5rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.btn {
+  padding: 0.6rem 1rem;
+  border-radius: 9999px;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  text-decoration: none;
+  transition: background 0.3s ease;
+}
+
+.btn:hover {
+  background: rgba(96, 165, 250, 0.2);
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: var(--navy);
+  color: #bbb;
+}

--- a/docs/typewriter.js
+++ b/docs/typewriter.js
@@ -1,0 +1,35 @@
+const phrases = [
+  'AI researcher',
+  'Builder',
+  'Explorer of Generative Frontiers'
+];
+let i = 0;
+let j = 0;
+let isDeleting = false;
+const speed = 100;
+const element = document.getElementById('typewriter');
+
+function type() {
+  const full = phrases[i];
+
+  if (!isDeleting) {
+    element.textContent = full.substring(0, j + 1);
+    j++;
+    if (j === full.length) {
+      isDeleting = true;
+      return setTimeout(type, 1500);
+    }
+  } else {
+    element.textContent = full.substring(0, j - 1);
+    j--;
+    if (j === 0) {
+      isDeleting = false;
+      i = (i + 1) % phrases.length;
+      return setTimeout(type, 500);
+    }
+  }
+
+  setTimeout(type, isDeleting ? speed / 2 : speed);
+}
+
+document.addEventListener('DOMContentLoaded', type);


### PR DESCRIPTION
## Summary
- restore earlier portfolio layout with Rubik's Cube on the home page
- rename original Bitcoin chart to `bitcoin.html`
- add colorful style/theme and improve typewriter script
- provide About, Projects, and Resume pages as placeholders
- include simple cube controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687a6a693d188333854ecbaf28a266d4