### PR TITLE
Fix cube rendering and scrambling

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -29,6 +29,8 @@ body {
 }
 
 nav {
+  position: relative;
+  z-index: 5;
   background: linear-gradient(90deg, var(--navy), var(--primary));
   color: #fff;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- adjust renderer to sit behind page content
- store cubelet start orientations and apply during rotation
- use a callback-based rotation loop for better scrambling
- ensure navigation bar overlays 3D canvas

## Testing
- `node -c docs/cube3d.js`

------
https://chatgpt.com/codex/tasks/task_b_687a9105c054833397ad3bd6a35f6c91