### PR TITLE
Integrate Three.js cube into main page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,37 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Sam Carter</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="cube.css">
+  <style>
+    canvas { display:block; }
+    #sidebar {
+      position:absolute;
+      top:20px; left:20px;
+      width:250px;
+      background:rgba(255,255,255,0.95);
+      padding:20px;
+      border-radius:10px;
+      box-shadow:0 0 15px rgba(0,0,0,0.5);
+      z-index:10;
+    }
+    #sidebar button, #sidebar input {
+      display:block;
+      width:100%;
+      padding:12px;
+      margin:10px 0;
+      font-size:16px;
+      cursor:pointer;
+      background:#2196F3;
+      color:white;
+      border:none;
+      border-radius:5px;
+      transition:transform 0.2s, background 0.3s;
+    }
+    #sidebar button:hover, #sidebar input:hover {
+      background:#1976D2;
+      transform:scale(1.05);
+    }
+    #status { text-align:center; color:#333; margin-top:10px; }
+  </style>
 </head>
 <body>
   <nav>
@@ -16,6 +46,13 @@
     <a href="resume.html">Resume</a>
     <a href="bitcoin.html">Bitcoin</a>
   </nav>
+  <div id="sidebar">
+    <input type="number" id="cubeSize" min="2" value="3" placeholder="Cube Size (e.g., 3)">
+    <button id="startBtn">Start</button>
+    <button id="scrambleBtn">Scramble</button>
+    <button id="solveBtn">Solve</button>
+    <div id="status">Press F/U/R/L/D/B + number (0 to size-1) to rotate layers</div>
+  </div>
   <header>
     <h1>Sam Carter</h1>
     <h2 id="typewriter"></h2>
@@ -24,15 +61,10 @@
     <p>Lab tech and robotics instructor.</p>
     <p>Specializes in 3D printing and hands-on STEM education.</p>
     <p>Currently exploring <strong>AI</strong> research at <strong>MiraCosta College</strong>.</p>
-    <div class="buttons">
-      <button id="scramble" class="btn">Scramble</button>
-      <button id="solve" class="btn">Solve</button>
-    </div>
-    <div id="scene"><div id="cube"></div></div>
-    <p style="text-align:center">Use keys U, D, F, B, L, R to rotate faces. Drag to spin the cube.</p>
   </main>
   <footer>© 2025 Sam Carter</footer>
   <script src="typewriter.js"></script>
-  <script src="cube.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script src="cube3d.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove CSS cube from main page
- add inline styles and sidebar markup from the cube demo
- load three.js and cube3d.js instead of cube.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687aa2db9cd48333893cf992fd596986