### PR TITLE
Simplify home page and revert cube code

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,36 +8,8 @@
   <link rel="stylesheet" href="cube.css">
 </head>
 <body class="noscroll">
-  <nav>
-    <a class="logo" href="index.html">Sam Carter</a>
-    <a href="about.html">About</a>
-    <a href="projects.html">Projects</a>
-    <a href="resume.html">Resume</a>
-  </nav>
-  <header>
-    <h1>Sam Carter</h1>
-    <h2 id="typewriter"></h2>
-  </header>
-  <main class="split intro">
-    <div>
-      <p>Machine technician and AI explorer specializing in 3D printing.</p>
-      <p>Currently at <strong>MiraCosta College</strong> pursuing an Associate's in AI and serving on the CSIT Advisory Board. Planning a Bachelor's in CSIT at <strong>Point Loma National University</strong>.</p>
-      <div class="buttons">
-        <button id="scramble" class="btn">Scramble</button>
-        <button id="solve" class="btn">Solve</button>
-      </div>
-    </div>
-    <div id="scene"></div>
-  </main>
-  <footer>
-    <nav class="footer-nav">
-      <a href="about.html">About</a>
-      <a href="projects.html">Projects</a>
-      <a href="resume.html">Resume</a>
-    </nav>
-    © 2025 Sam Carter
-  </footer>
-  <script src="typewriter.js"></script>
+  <p style="text-align:center">Try the interactive Rubik's Cube below.</p>
+  <div id="scene" style="margin:auto; width:320px; height:320px;"></div>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
   <script src="cube3d_embed.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- trim the homepage down to just a sentence and the embedded cube
- revert cube embed script to a stable version and make scramble/solve buttons optional

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687ab5c254d88333b5222da6bb2d2547