### PR TITLE
Clean footer and disable cube controls

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -36,12 +36,6 @@
   </main>
 
   <footer>
-    <nav class="footer-nav">
-      <a href="about.html">About</a>
-      <a href="projects.html">Projects</a>
-      <a href="resume.html">Resume</a>
-      <a href="bitcoin.html">Bitcoin</a>
-    </nav>
     © 2025 Sam Carter — more info coming soon
   </footer>
 </body>

--- a/docs/cube3d_embed.js
+++ b/docs/cube3d_embed.js
@@ -98,14 +98,7 @@ function onKeyDown(event) {
   }
 }
 
-let keyboardEnabled = false;
-function enableKeyboard() {
-  if (!keyboardEnabled) {
-    document.addEventListener('keydown', onKeyDown);
-    keyboardEnabled = true;
-  }
-}
-renderer.domElement.addEventListener('pointerdown', enableKeyboard);
+// Disable manual cube manipulation
 
 function startLayerRotation(center, axis) {
   isRotatingLayer = true;
@@ -159,22 +152,23 @@ function animateRotation(cb) {
   }
 }
 
-renderer.domElement.addEventListener('mousedown', e => {
-  if (isRotatingLayer) return;
-  isDragging = true;
-  previousMousePosition = { x: e.clientX, y: e.clientY };
-});
+// Disable drag rotation
+// renderer.domElement.addEventListener('mousedown', e => {
+//   if (isRotatingLayer) return;
+//   isDragging = true;
+//   previousMousePosition = { x: e.clientX, y: e.clientY };
+// });
 
-document.addEventListener('mousemove', e => {
-  if (isDragging && !isRotatingLayer) {
-    const delta = { x: -(e.clientX - previousMousePosition.x), y: -(e.clientY - previousMousePosition.y) };
-    const quat = new THREE.Quaternion().setFromEuler(new THREE.Euler(delta.y * 0.002, delta.x * 0.002, 0, 'XYZ'));
-    targetQuaternion.multiply(quat);
-    previousMousePosition = { x: e.clientX, y: e.clientY };
-  }
-});
+// document.addEventListener('mousemove', e => {
+//   if (isDragging && !isRotatingLayer) {
+//     const delta = { x: -(e.clientX - previousMousePosition.x), y: -(e.clientY - previousMousePosition.y) };
+//     const quat = new THREE.Quaternion().setFromEuler(new THREE.Euler(delta.y * 0.002, delta.x * 0.002, 0, 'XYZ'));
+//     targetQuaternion.multiply(quat);
+//     previousMousePosition = { x: e.clientX, y: e.clientY };
+//   }
+// });
 
-document.addEventListener('mouseup', () => { isDragging = false; });
+// document.addEventListener('mouseup', () => { isDragging = false; });
 
 function animate() {
   requestAnimationFrame(animate);

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,12 +31,6 @@
     <div id="scene"></div>
   </main>
   <footer>
-    <nav class="footer-nav">
-      <a href="about.html">About</a>
-      <a href="projects.html">Projects</a>
-      <a href="resume.html">Resume</a>
-      <a href="bitcoin.html">Bitcoin</a>
-    </nav>
     © 2025 Sam Carter
   </footer>
   <script src="typewriter.js"></script>

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -36,12 +36,6 @@
   </main>
 
   <footer>
-    <nav class="footer-nav">
-      <a href="about.html">About</a>
-      <a href="projects.html">Projects</a>
-      <a href="resume.html">Resume</a>
-      <a href="bitcoin.html">Bitcoin</a>
-    </nav>
     © 2025 Sam Carter — projects coming soon
   </footer>
 </body>

--- a/docs/resume.html
+++ b/docs/resume.html
@@ -67,12 +67,6 @@
     </section>
   </main>
   <footer>
-    <nav class="footer-nav">
-      <a href="about.html">About</a>
-      <a href="projects.html">Projects</a>
-      <a href="resume.html">Resume</a>
-      <a href="bitcoin.html">Bitcoin</a>
-    </nav>
     © 2025 Sam Carter
   </footer>
 </body>


### PR DESCRIPTION
## Summary
- remove footer navigation links for a cleaner layout
- disable mouse and keyboard cube manipulation so only the scramble/solve buttons work

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687aba61e3a88333a47e18c91d7c9e8d