### PR TITLE
Improve scramble logic and UI

### DIFF
--- a/docs/cube.js
+++ b/docs/cube.js
@@ -166,9 +166,15 @@ function queueMove(face, inverse=false) {
 
 function scramble() {
   const faces = Object.keys(moveDefs);
+  const opposite = {U:'D', D:'U', F:'B', B:'F', L:'R', R:'L'};
+  let last = null;
   for (let i=0;i<20;i++) {
-    const f = faces[Math.floor(Math.random()*faces.length)];
+    let f;
+    do {
+      f = faces[Math.floor(Math.random()*faces.length)];
+    } while (f === last || opposite[f] === last);
     queueMove(f);
+    last = f;
   }
 }
 

--- a/docs/cube3d.js
+++ b/docs/cube3d.js
@@ -180,13 +180,20 @@ function scramble() {
   if (isRotatingLayer) return;
   const moves = 20;
   const axes = Object.values(keyMap);
+  let lastAxis = null;
+  let lastLayer = null;
   let i = 0;
   function doMove() {
     if (i >= moves) return;
-    const axis = axes[Math.floor(Math.random() * 6)];
-    const layer = Math.floor(Math.random() * cubeSize) - (cubeSize - 1) / 2;
+    let axis, layer;
+    do {
+      axis = axes[Math.floor(Math.random() * 6)];
+      layer = Math.floor(Math.random() * cubeSize) - (cubeSize - 1) / 2;
+    } while ((lastAxis && axis.equals(lastAxis) && (layer === lastLayer || layer === -lastLayer)));
     const center = axis.clone().multiplyScalar(layer);
     startLayerRotation(center, axis);
+    lastAxis = axis.clone();
+    lastLayer = layer;
     i++;
     animateRotation(() => doMove());
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,6 +10,7 @@
 <body>
   <nav>
     <a class="logo" href="index.html">Sam Carter</a>
+    <a href="index.html">Home</a>
     <a href="projects.html">Projects</a>
     <a href="resume.html">Resume</a>
   </nav>

--- a/docs/resume.css
+++ b/docs/resume.css
@@ -1,4 +1,4 @@
 body {
-  background: var(--navy);
+  background: #222;
   animation: none;
 }

--- a/docs/resume.html
+++ b/docs/resume.html
@@ -10,6 +10,7 @@
 <body>
   <nav>
     <a class="logo" href="index.html">Sam Carter</a>
+    <a href="index.html">Home</a>
     <a href="projects.html">Projects</a>
     <a href="resume.html">Resume</a>
   </nav>

--- a/docs/style.css
+++ b/docs/style.css
@@ -29,13 +29,15 @@ body {
 }
 
 nav {
-  position: relative;
+  position: sticky;
+  top: 0;
   z-index: 5;
   background: linear-gradient(90deg, var(--navy), var(--primary));
   color: #fff;
   padding: 1rem;
   display: flex;
   gap: 1rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
 }
 
 nav a {


### PR DESCRIPTION
## Summary
- keep navigation visible with sticky top nav
- adjust resume page background
- keep home link available
- avoid repeating moves when scrambling the cube (2D and 3D)

## Testing
- `npm test` *(fails: cannot find package.json)*
- `npm run lint` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_687ad3ee32dc83339e06c7fb056e52df