### PR TITLE
Improve banner and cube interactions

### DIFF
--- a/docs/cube3d_embed.js
+++ b/docs/cube3d_embed.js
@@ -201,6 +201,11 @@ function runSequence(moves, onDone) {
 
 function scramble() {
   if (isRotatingLayer || runningSequence) return;
+  const scrambleBtn = document.getElementById('scramble');
+  const solveBtn = document.getElementById('solve');
+  scrambleBtn.textContent = 'Scrambling...';
+  scrambleBtn.disabled = true;
+  solveBtn.disabled = true;
   const axes = Object.values(keyMap);
   const moves = [];
   for (let i = 0; i < 20; i++) {
@@ -211,11 +216,20 @@ function scramble() {
   }
   scrambleHistory.length = 0;
   scrambleHistory.push(...moves);
-  runSequence(moves);
+  runSequence(moves, () => {
+    scrambleBtn.textContent = 'Scramble';
+    scrambleBtn.disabled = false;
+    solveBtn.disabled = false;
+  });
 }
 
 function solve() {
   if (isRotatingLayer) return;
+  const solveBtn = document.getElementById('solve');
+  const scrambleBtn = document.getElementById('scramble');
+  solveBtn.textContent = 'Solving...';
+  solveBtn.disabled = true;
+  scrambleBtn.disabled = true;
   let moves;
   if (runningSequence) {
     moves = executedMoves.slice().reverse().map(m => ({ axis: m.axis.clone().negate(), center: m.center }));
@@ -223,7 +237,12 @@ function solve() {
   } else {
     moves = scrambleHistory.slice().reverse().map(m => ({ axis: m.axis.clone().negate(), center: m.center }));
   }
-  runSequence(moves, () => { scrambleHistory.length = 0; });
+  runSequence(moves, () => {
+    scrambleHistory.length = 0;
+    solveBtn.textContent = 'Solve';
+    solveBtn.disabled = false;
+    scrambleBtn.disabled = false;
+  });
 }
 
 document.getElementById('scramble').addEventListener('click', scramble);

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -27,8 +27,9 @@
       </div>
       <div class="card">
         <h2>Robotics Mentorship</h2>
-        <p>Developed curriculum and mentored more than 50 middle school teams
-        through the Carlsbad Educational Foundation.</p>
+        <p>Developed curriculum and mentored over 50 middle school teams with
+        more than 2,500 hours of hands-on guidance through the Carlsbad
+        Educational Foundation.</p>
       </div>
     </div>
   </main>

--- a/docs/resume.html
+++ b/docs/resume.html
@@ -61,8 +61,8 @@
         <li>President, CHS Robotics Club (2018 – 2019)</li>
         <li>Captain, FTC Team 5015 Buffalo Wings (2017 – 2018)</li>
         <li>Captain, FTC Team 6226 Bambusa (2016 – 2017)</li>
-        <li>1,250+ hours mentoring robotics teams</li>
-        <li>Coached/Mentored 50+ teams</li>
+        <li>2,500+ hours mentoring robotics teams</li>
+        <li>Coached/Mentored over 50 teams</li>
       </ul>
     </section>
   </main>

--- a/docs/style.css
+++ b/docs/style.css
@@ -171,6 +171,11 @@ section {
   font-weight: 300;
 }
 
+#typewriter {
+  display: inline-block;
+  min-height: 2rem;
+}
+
 .cursor {
   display: inline-block;
   width: 2px;

--- a/docs/typewriter.js
+++ b/docs/typewriter.js
@@ -1,7 +1,7 @@
 const phrases = [
-  'Machine technician',
-  'AI explorer',
-  '3D printing specialist'
+  'Machine tech & robotics mentor',
+  'AI trailblazer',
+  '3D printing expert'
 ];
 let i = 0;
 let j = 0;
@@ -23,6 +23,7 @@ function type() {
     element.textContent = full.substring(0, j - 1);
     j--;
     if (j === 0) {
+      element.innerHTML = '&nbsp;';
       isDeleting = false;
       i = (i + 1) % phrases.length;
       return setTimeout(type, 500);


### PR DESCRIPTION
## Summary
- update rotating banner phrases
- hold header height during phrase transitions
- toggle button states when scrambling or solving cube
- note 2,500 hours of mentoring

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `npx eslint docs/typewriter.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_687ad6ec1e1c83339232aebcca48969f