### PR TITLE
Restore cube colors

### DIFF
--- a/docs/cube3d_embed.js
+++ b/docs/cube3d_embed.js
@@ -22,8 +22,14 @@ const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
 directionalLight.position.set(5, 5, 5).normalize();
 scene.add(directionalLight);
 
-const faceColors = [0x222222, 0x252525, 0x282828, 0x2b2b2b, 0x2e2e2e, 0x313131];
-const colors = faceColors.map(c => new THREE.MeshPhongMaterial({ color: c, shininess: 40 }));
+const colors = [
+  new THREE.MeshPhongMaterial({ color: 0xff4d4d, shininess: 50 }), // front
+  new THREE.MeshPhongMaterial({ color: 0x4d79ff, shininess: 50 }), // back
+  new THREE.MeshPhongMaterial({ color: 0xffffff, shininess: 50 }), // up
+  new THREE.MeshPhongMaterial({ color: 0xffea00, shininess: 50 }), // down
+  new THREE.MeshPhongMaterial({ color: 0x4dff4d, shininess: 50 }), // left
+  new THREE.MeshPhongMaterial({ color: 0xff9933, shininess: 50 })  // right
+];
 const hiddenMaterial = new THREE.MeshPhongMaterial({ color: 0x2f2f2f, shininess: 50 });
 
 let cubeSize = 3;


### PR DESCRIPTION
## Summary
- restore vibrant cube colors in 3D cube embed script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687b0b56d8a48333b425a83cc29ba76a