### PR TITLE
Fix cube not visible when styles not loaded

### DIFF
--- a/docs/cube3d_embed.js
+++ b/docs/cube3d_embed.js
@@ -4,8 +4,13 @@
 const scene = new THREE.Scene();
 const container = document.getElementById('scene');
 const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-const width = container.clientWidth;
-const height = container.clientHeight;
+let width = container.clientWidth;
+let height = container.clientHeight;
+// Fallback if styles haven't loaded yet
+if (!width || !height) {
+  width = 320;
+  height = 320;
+}
 const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
 renderer.setSize(width, height);
 container.appendChild(renderer.domElement);


### PR DESCRIPTION
## Summary
- fix 3D cube width/height fallback so the cube appears even if styles aren't loaded when JS runs

## Testing
- `node -e "require('fs').readFileSync('docs/cube3d_embed.js');"`

------
https://chatgpt.com/codex/tasks/task_b_687bb407092883338b7956053f2ca871