### PR TITLE
Add avatar and logos; tweak footer and typewriter

### DIFF
--- a/docs/img/avatar.svg
+++ b/docs/img/avatar.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <circle cx="60" cy="60" r="58" fill="url(#grad)" stroke="#444" stroke-width="4"/>
+  <defs>
+    <linearGradient id="grad" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#eab308"/>
+    </linearGradient>
+  </defs>
+  <circle cx="40" cy="50" r="10" fill="#fff"/>
+  <circle cx="80" cy="50" r="10" fill="#fff"/>
+  <path d="M40 80 Q60 100 80 80" stroke="#fff" stroke-width="6" fill="none" stroke-linecap="round"/>
+</svg>

--- a/docs/img/miracosta.svg
+++ b/docs/img/miracosta.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <rect width="200" height="60" rx="8" fill="#004b8d"/>
+  <path d="M0 45 Q50 20 100 45 T200 45" fill="none" stroke="#fff" stroke-width="5"/>
+  <text x="100" y="38" font-size="24" font-family="Arial, sans-serif" text-anchor="middle" fill="#fff">MiraCosta</text>
+</svg>

--- a/docs/img/plnu.svg
+++ b/docs/img/plnu.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <rect width="200" height="60" rx="8" fill="#115e59"/>
+  <text x="100" y="38" font-size="26" font-family="Arial, sans-serif" text-anchor="middle" fill="#fff">PLNU</text>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,9 +18,14 @@
     <h2 id="typewriter"></h2>
   </header>
   <main class="split intro">
+    <img src="img/avatar.svg" alt="Placeholder avatar" class="avatar">
     <div>
-      <p>Machine technician and AI explorer specializing in 3D printing.</p>
+      <p>3D printing specialist and hardware hacker exploring AI.</p>
       <p>Currently at <strong>MiraCosta College</strong> pursuing an Associate's in AI and serving on the CSIT Advisory Board. Planning a Bachelor's at <strong>Point Loma Nazarene University</strong>.</p>
+      <div class="logos">
+        <img src="img/miracosta.svg" alt="MiraCosta College logo" class="school-logo">
+        <img src="img/plnu.svg" alt="Point Loma Nazarene University logo" class="school-logo">
+      </div>
     </div>
   </main>
   <footer>

--- a/docs/style.css
+++ b/docs/style.css
@@ -26,6 +26,9 @@ body {
   color: #eee;
   animation: gradient 20s ease infinite;
   font-size: 1.2rem;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 nav {
@@ -125,6 +128,15 @@ h2 {
   padding: 1rem 0;
 }
 
+.logos {
+  margin-top: 1rem;
+}
+
+.school-logo {
+  height: 40px;
+  margin-right: 0.5rem;
+}
+
 .badge {
   white-space: nowrap;
   padding: 0.3rem 0.8rem;
@@ -156,6 +168,7 @@ main {
   max-width: 900px;
   margin: auto;
   padding: 1rem;
+  flex: 1;
 }
 
 section {

--- a/docs/typewriter.js
+++ b/docs/typewriter.js
@@ -1,10 +1,9 @@
 const basePhrases = [
-  'Machine tech & robotics mentor',
-  'AI trailblazer',
-  '3D printing expert',
-  'Coding fanatic',
+  '3D printing specialist',
   'Hardware hacker',
-  'Relentless problem solver'
+  'Coding fanatic',
+  'Creative maker',
+  'Lifelong learner'
 ];
 
 function shuffle(arr) {


### PR DESCRIPTION
## Summary
- add placeholder avatar SVG and college logos
- include avatar and logos on the home page
- keep footer at bottom of the screen
- update rotating tagline phrases

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687bfe7908c48333a0c3791b433c599e