### PR TITLE
Add MCP3008 project page

### DIFF
--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>MCP3008 ADC • Sam Carter</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <a class="logo" href="index.html">Sam Carter</a>
+    <a href="index.html">Home</a>
+    <a href="projects.html">Projects</a>
+    <a href="resume.html">Resume</a>
+    <a href="#" class="back-button" onclick="history.back();return false;">Back</a>
+  </nav>
+  <header class="hero">
+    <h1>MCP3008 ADC</h1>
+  </header>
+  <main>
+    <p>I wired a real MCP3008 chip to my Raspberry Pi to read analog sensors.</p>
+    <p>With eight 10‑bit channels over SPI, the MCP3008 let me adjust a servo in Python using a simple potentiometer.</p>
+  </main>
+  <footer>
+    © 2025 Sam Carter
+  </footer>
+</body>
+</html>

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -29,6 +29,10 @@
         <h2>Robotics Mentorship</h2>
         <p>Mentored 50+ middle school teams and built hands-on curriculum for the Carlsbad Educational Foundation.</p>
       </a>
+      <a class="card" href="mcp.html">
+        <h2>MCP3008 Example</h2>
+        <p>Used a real MCP3008 ADC with a Raspberry Pi to read sensors and control a servo.</p>
+      </a>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- add a new MCP3008 project page describing how a real MCP3008 ADC was used
- link the new page from the Projects list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687f04f9af048333a72f4abf508b92b4