### PR TITLE
Add prompt store

### DIFF
--- a/docs/3d-printing.html
+++ b/docs/3d-printing.html
@@ -11,6 +11,7 @@
     <a class="logo" href="index.html">Sam Carter</a>
     <a href="index.html">Home</a>
     <a href="projects.html">Projects</a>
+    <a href="prompts.html">Prompts</a>
     <a href="resume.html">Resume</a>
     <a href="#" class="back-button" onclick="history.back();return false;">Back</a>
   </nav>

--- a/docs/about.html
+++ b/docs/about.html
@@ -11,6 +11,7 @@
     <a class="logo" href="index.html">Sam Carter</a>
     <a href="index.html">Home</a>
     <a href="projects.html">Projects</a>
+    <a href="prompts.html">Prompts</a>
     <a href="resume.html">Resume</a>
     <a href="#" class="back-button" onclick="history.back();return false;">Back</a>
   </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,7 @@
     <a class="logo" href="index.html">Sam Carter</a>
     <a href="index.html">Home</a>
     <a href="projects.html">Projects</a>
+    <a href="prompts.html">Prompts</a>
     <a href="resume.html">Resume</a>
     <a href="#" class="back-button" onclick="history.back();return false;">Back</a>
   </nav>

--- a/docs/mcp.html
+++ b/docs/mcp.html
@@ -11,6 +11,7 @@
     <a class="logo" href="index.html">Sam Carter</a>
     <a href="index.html">Home</a>
     <a href="projects.html">Projects</a>
+    <a href="prompts.html">Prompts</a>
     <a href="resume.html">Resume</a>
     <a href="#" class="back-button" onclick="history.back();return false;">Back</a>
   </nav>

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -11,6 +11,7 @@
     <a class="logo" href="index.html">Sam Carter</a>
     <a href="index.html">Home</a>
     <a href="projects.html">Projects</a>
+    <a href="prompts.html">Prompts</a>
     <a href="resume.html">Resume</a>
     <a href="#" class="back-button" onclick="history.back();return false;">Back</a>
   </nav>

--- a/docs/prompts.html
+++ b/docs/prompts.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Prompt Store • Sam Carter</title>
+  <link rel="stylesheet" href="style.css">
+  <script defer src="prompts.js"></script>
+</head>
+<body>
+  <nav>
+    <a class="logo" href="index.html">Sam Carter</a>
+    <a href="index.html">Home</a>
+    <a href="projects.html">Projects</a>
+    <a href="prompts.html">Prompts</a>
+    <a href="resume.html">Resume</a>
+    <a href="#" class="back-button" onclick="history.back();return false;">Back</a>
+  </nav>
+  <header class="hero">
+    <h1>Prompt Store</h1>
+    <p>Browse AI prompts ready for purchase. Click any example to preview results!</p>
+  </header>
+  <main>
+    <div class="gallery">
+      <div class="prompt-card">
+        <h2>Social Media Post</h2>
+        <p class="prompt-text">"Write a captivating tweet about the future of AI."</p>
+        <button class="show-output">Show Example</button>
+        <p class="prompt-output">"Unlock the power of tomorrow with AI innovation! 🚀"</p>
+      </div>
+      <div class="prompt-card">
+        <h2>Product Description</h2>
+        <p class="prompt-text">"Describe a sleek new smartwatch in two sentences."</p>
+        <button class="show-output">Show Example</button>
+        <p class="prompt-output">"Stay connected in style with our minimalist smartwatch that keeps you on schedule and in touch."</p>
+      </div>
+      <div class="prompt-card">
+        <h2>Newsletter Intro</h2>
+        <p class="prompt-text">"Create an engaging opening for a tech trends newsletter."</p>
+        <button class="show-output">Show Example</button>
+        <p class="prompt-output">"Welcome to this week's dive into emerging tech shaping our lives."</p>
+      </div>
+    </div>
+  </main>
+  <footer>
+    © <span data-year></span> Sam Carter
+  </footer>
+  <script src="year.js"></script>
+</body>
+</html>

--- a/docs/prompts.js
+++ b/docs/prompts.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.show-output').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const output = btn.nextElementSibling;
+      if (!output) return;
+      if (output.style.display === 'block') {
+        output.style.display = 'none';
+        btn.textContent = 'Show Example';
+      } else {
+        output.style.display = 'block';
+        btn.textContent = 'Hide Example';
+      }
+    });
+  });
+});

--- a/docs/resume.html
+++ b/docs/resume.html
@@ -12,6 +12,7 @@
     <a class="logo" href="index.html">Sam Carter</a>
     <a href="index.html">Home</a>
     <a href="projects.html">Projects</a>
+    <a href="prompts.html">Prompts</a>
     <a href="resume.html">Resume</a>
     <a href="#" class="back-button" onclick="history.back();return false;">Back</a>
   </nav>

--- a/docs/robotics.html
+++ b/docs/robotics.html
@@ -11,6 +11,7 @@
     <a class="logo" href="index.html">Sam Carter</a>
     <a href="index.html">Home</a>
     <a href="projects.html">Projects</a>
+    <a href="prompts.html">Prompts</a>
     <a href="resume.html">Resume</a>
     <a href="#" class="back-button" onclick="history.back();return false;">Back</a>
   </nav>

--- a/docs/style.css
+++ b/docs/style.css
@@ -230,3 +230,32 @@ footer {
 .footer-nav a:hover {
   color: #fff;
 }
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.prompt-card {
+  background: rgba(255,255,255,0.05);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.prompt-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 15px rgba(0,0,0,0.3);
+}
+
+.prompt-text {
+  font-style: italic;
+}
+
+.prompt-output {
+  display: none;
+  margin-top: 0.5rem;
+  color: var(--accent2);
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated prompt store with example gallery
- link to the new store from all pages
- style prompt cards and add JS for toggling examples

## Testing
- `tidy -qe docs/prompts.html`
- `for f in docs/*.html; do tidy -qe "$f"; done`

------
https://chatgpt.com/codex/tasks/task_b_6882624b72488333a94fdf021dbfaa9b