### PR TITLE
Enhance prompt gallery with interactive reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AI Prompt Gallery
 
-A minimal static page with a few example prompts and outputs.
+A simple static page showcasing AI prompt ideas. Each example card now lets you reveal the output with a button for a more interactive experience.
 
-Open `index.html` in your browser to see the gallery.
+Open `index.html` in your browser to explore the gallery.

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,31 +13,51 @@
       <h2>Time Travel Journal</h2>
       <p class="prompt-text">You arrive in 2050. Describe the first page of your travel diary.</p>
       <p class="prompt-output">"Entry 1: The skies hum with silent drones and neon rails glide above the cityscape..."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/musical/400/200" alt="ai musical">
       <h2>AI Musical</h2>
       <p class="prompt-text">Pitch a Broadway-style musical about friendly robots.</p>
       <p class="prompt-output">"Imagine tap-dancing androids singing in perfect harmony about data dreams and digital hearts."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/galactic/400/200" alt="galactic cooking">
       <h2>Galactic Cooking Show</h2>
       <p class="prompt-text">Give a one-sentence teaser for an interstellar cooking show.</p>
       <p class="prompt-output">"Tonight's chef crafts zero-gravity soufflés using flavors from across the cosmos."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/underwater/400/200" alt="underwater city">
       <h2>Underwater Ad</h2>
       <p class="prompt-text">Write a catchy ad for luxury apartments in an underwater city.</p>
       <p class="prompt-output">"Live among colorful coral towers and wake up to dancing rays of aqua light."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/dragon/400/200" alt="dragon translator">
       <h2>Dragon Translator</h2>
       <p class="prompt-text">Translate 'Hello, friend!' into dragon-speak for a fantasy novel.</p>
       <p class="prompt-output">"Grathul rithen!"</p>
+      <button class="reveal-button">Show Output</button>
+    </div>
+    <div class="prompt-card">
+      <img src="https://picsum.photos/seed/quantum/400/200" alt="quantum heist">
+      <h2>Quantum Heist</h2>
+      <p class="prompt-text">Outline a clever plan to steal energy from a micro singularity without collapsing space-time.</p>
+      <p class="prompt-output">"The crew uses entangled drones to divert gravitational waves just long enough to siphon a spark of boundless power."</p>
+      <button class="reveal-button">Show Output</button>
+    </div>
+    <div class="prompt-card">
+      <img src="https://picsum.photos/seed/hauntedship/400/200" alt="haunted spaceship">
+      <h2>Haunted Spaceship Log</h2>
+      <p class="prompt-text">Write the opening log entry of a captain convinced their AI ship is haunted.</p>
+      <p class="prompt-output">"Day 1: The control panels flicker with cryptic messages, and I swear the engines sigh like ghosts in the void."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
   </div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.reveal-button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const output = btn.parentElement.querySelector('.prompt-output');
+      if (output) {
+        output.classList.toggle('show');
+        btn.textContent = output.classList.contains('show') ? 'Hide Output' : 'Show Output';
+      }
+    });
+  });
+});

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,6 +1,50 @@
-body{font-family:sans-serif;background:#fafafa;margin:0;padding:0;text-align:center;}
-.gallery{display:flex;flex-wrap:wrap;gap:1rem;justify-content:center;padding:1rem;}
-.prompt-card{background:#fff;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);padding:1rem;width:320px;}
-.prompt-card img{width:100%;border-radius:4px;}
-.prompt-text{font-style:italic;}
-.prompt-output{color:#10b981;margin-top:.5rem;}
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(to right, #f9fafb, #e0f7fa);
+  margin: 0;
+  padding: 0;
+  text-align: center;
+}
+.gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  padding: 1rem;
+}
+.prompt-card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  width: 320px;
+  position: relative;
+  transition: transform 0.2s;
+}
+.prompt-card:hover {
+  transform: translateY(-5px);
+}
+.prompt-card img {
+  width: 100%;
+  border-radius: 4px;
+}
+.prompt-text {
+  font-style: italic;
+}
+.prompt-output {
+  color: #10b981;
+  margin-top: 0.5rem;
+  display: none;
+}
+.prompt-output.show {
+  display: block;
+}
+.reveal-button {
+  margin-top: 0.5rem;
+  background: #10b981;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}

--- a/index.html
+++ b/index.html
@@ -13,31 +13,51 @@
       <h2>Time Travel Journal</h2>
       <p class="prompt-text">You arrive in 2050. Describe the first page of your travel diary.</p>
       <p class="prompt-output">"Entry 1: The skies hum with silent drones and neon rails glide above the cityscape..."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/musical/400/200" alt="ai musical">
       <h2>AI Musical</h2>
       <p class="prompt-text">Pitch a Broadway-style musical about friendly robots.</p>
       <p class="prompt-output">"Imagine tap-dancing androids singing in perfect harmony about data dreams and digital hearts."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/galactic/400/200" alt="galactic cooking">
       <h2>Galactic Cooking Show</h2>
       <p class="prompt-text">Give a one-sentence teaser for an interstellar cooking show.</p>
       <p class="prompt-output">"Tonight's chef crafts zero-gravity soufflés using flavors from across the cosmos."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/underwater/400/200" alt="underwater city">
       <h2>Underwater Ad</h2>
       <p class="prompt-text">Write a catchy ad for luxury apartments in an underwater city.</p>
       <p class="prompt-output">"Live among colorful coral towers and wake up to dancing rays of aqua light."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/dragon/400/200" alt="dragon translator">
       <h2>Dragon Translator</h2>
       <p class="prompt-text">Translate 'Hello, friend!' into dragon-speak for a fantasy novel.</p>
       <p class="prompt-output">"Grathul rithen!"</p>
+      <button class="reveal-button">Show Output</button>
+    </div>
+    <div class="prompt-card">
+      <img src="https://picsum.photos/seed/quantum/400/200" alt="quantum heist">
+      <h2>Quantum Heist</h2>
+      <p class="prompt-text">Outline a clever plan to steal energy from a micro singularity without collapsing space-time.</p>
+      <p class="prompt-output">"The crew uses entangled drones to divert gravitational waves just long enough to siphon a spark of boundless power."</p>
+      <button class="reveal-button">Show Output</button>
+    </div>
+    <div class="prompt-card">
+      <img src="https://picsum.photos/seed/hauntedship/400/200" alt="haunted spaceship">
+      <h2>Haunted Spaceship Log</h2>
+      <p class="prompt-text">Write the opening log entry of a captain convinced their AI ship is haunted.</p>
+      <p class="prompt-output">"Day 1: The control panels flicker with cryptic messages, and I swear the engines sigh like ghosts in the void."</p>
+      <button class="reveal-button">Show Output</button>
     </div>
   </div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.reveal-button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const output = btn.parentElement.querySelector('.prompt-output');
+      if (output) {
+        output.classList.toggle('show');
+        btn.textContent = output.classList.contains('show') ? 'Hide Output' : 'Show Output';
+      }
+    });
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,6 +1,50 @@
-body{font-family:sans-serif;background:#fafafa;margin:0;padding:0;text-align:center;}
-.gallery{display:flex;flex-wrap:wrap;gap:1rem;justify-content:center;padding:1rem;}
-.prompt-card{background:#fff;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);padding:1rem;width:320px;}
-.prompt-card img{width:100%;border-radius:4px;}
-.prompt-text{font-style:italic;}
-.prompt-output{color:#10b981;margin-top:.5rem;}
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background: linear-gradient(to right, #f9fafb, #e0f7fa);
+  margin: 0;
+  padding: 0;
+  text-align: center;
+}
+.gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  padding: 1rem;
+}
+.prompt-card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  width: 320px;
+  position: relative;
+  transition: transform 0.2s;
+}
+.prompt-card:hover {
+  transform: translateY(-5px);
+}
+.prompt-card img {
+  width: 100%;
+  border-radius: 4px;
+}
+.prompt-text {
+  font-style: italic;
+}
+.prompt-output {
+  color: #10b981;
+  margin-top: 0.5rem;
+  display: none;
+}
+.prompt-output.show {
+  display: block;
+}
+.reveal-button {
+  margin-top: 0.5rem;
+  background: #10b981;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add reveal-button interactivity with `script.js`
- style updates for card hover and gradients
- add quantum and haunted spaceship prompts
- update README with site changes

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm run lint` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688276462a38833380f429375509ff5d