### PR TITLE
Add dark mode toggle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>AI Prompts</title>
+  <meta name="description" content="Gallery of fun AI prompt ideas with interactive reveal buttons.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <button id="theme-toggle">Dark Mode</button>
   <div class="gallery">
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/timetravel/400/200" alt="time travel">

--- a/docs/script.js
+++ b/docs/script.js
@@ -8,4 +8,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  const themeBtn = document.getElementById('theme-toggle');
+  if (themeBtn) {
+    themeBtn.addEventListener('click', () => {
+      document.body.classList.toggle('dark');
+      themeBtn.textContent = document.body.classList.contains('dark') ? 'Light Mode' : 'Dark Mode';
+    });
+  }
 });

--- a/docs/style.css
+++ b/docs/style.css
@@ -48,3 +48,21 @@ body {
   border-radius: 4px;
   cursor: pointer;
 }
+
+body.dark {
+  background: linear-gradient(to right, #1e293b, #0f172a);
+  color: #f9fafb;
+}
+
+body.dark .prompt-card {
+  background: #334155;
+  color: #f9fafb;
+}
+
+body.dark .prompt-output {
+  color: #34d399;
+}
+
+body.dark .reveal-button {
+  background: #34d399;
+}

--- a/index.html
+++ b/index.html
@@ -4,9 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>AI Prompts</title>
+  <meta name="description" content="Gallery of fun AI prompt ideas with interactive reveal buttons.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <button id="theme-toggle">Dark Mode</button>
   <div class="gallery">
     <div class="prompt-card">
       <img src="https://picsum.photos/seed/timetravel/400/200" alt="time travel">

--- a/script.js
+++ b/script.js
@@ -8,4 +8,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  const themeBtn = document.getElementById('theme-toggle');
+  if (themeBtn) {
+    themeBtn.addEventListener('click', () => {
+      document.body.classList.toggle('dark');
+      themeBtn.textContent = document.body.classList.contains('dark') ? 'Light Mode' : 'Dark Mode';
+    });
+  }
 });

--- a/style.css
+++ b/style.css
@@ -48,3 +48,21 @@ body {
   border-radius: 4px;
   cursor: pointer;
 }
+
+body.dark {
+  background: linear-gradient(to right, #1e293b, #0f172a);
+  color: #f9fafb;
+}
+
+body.dark .prompt-card {
+  background: #334155;
+  color: #f9fafb;
+}
+
+body.dark .prompt-output {
+  color: #34d399;
+}
+
+body.dark .reveal-button {
+  background: #34d399;
+}


### PR DESCRIPTION
## Summary
- enhance SEO by adding meta description
- add a button to toggle dark mode
- implement dark mode styles
- update JS to handle theme toggling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68829e94726c8333bb473fad4f5652db