### PR TITLE
Enhance Rubik's cube

### DIFF
--- a/docs/cube.css
+++ b/docs/cube.css
@@ -44,6 +44,17 @@
 #R { transform: rotateY(90deg) translateZ(60px); }
 
 .controls { text-align: center; margin-bottom: 1rem; }
+.controls button {
+  margin: 0 0.25rem;
+  padding: 0.4rem 0.8rem;
+  border: 1px solid #666;
+  background: #222;
+  color: #fff;
+  cursor: pointer;
+}
+.controls button:hover {
+  background: #333;
+}
 
 #cube.dragging {
   cursor: grabbing;

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,11 @@
     <p>Specializes in 3D printing and hands-on STEM education.</p>
     <p>Currently exploring <strong>AI</strong> research at <strong>MiraCosta College</strong>.</p>
     <div id="scene"><div id="cube"></div></div>
-    <p class="hint">Use the arrow keys or drag to rotate the view. Press U, D, F, B, L, or R to turn a face.</p>
+    <div class="controls">
+      <button id="scramble-btn">Scramble</button>
+      <button id="reset-btn">Reset</button>
+    </div>
+    <p class="hint">Use the arrow keys or drag to rotate the view. Click or tap a face to turn it. Drag a face left or right to turn the other way.</p>
   </main>
   <footer>© 2025 Sam Carter</footer>
   <script src="typewriter.js"></script>


### PR DESCRIPTION
## Summary
- add control buttons and updated hints on index page
- style cube controls
- allow clicking/tapping faces to turn them
- support scramble/reset buttons in script
- handle mobile taps and disable context menus

## Testing
- `node --check docs/cube.js`

------
https://chatgpt.com/codex/tasks/task_b_68865b5830c883338c9ab7f8a8aa6e85