### PR TITLE
Update site details and styles

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -23,19 +23,20 @@
   <main>
     <div class="split">
       <div>
-        <p>Hi, I'm Sam Carter, a lab technician and robotics instructor from
-        Carlsbad, California. At GKN Additive I managed SLA, PolyJet, and FDM
-        printers for custom manufacturing.</p>
+        <p>Hi, I'm Sam Carter, a machine technician and robotics instructor from
+        Carlsbad, California. At GKN Additive I maintain SLA, PolyJet and FDM
+        printers used for custom manufacturing.</p>
         <p>I've coordinated robotics programs with the Carlsbad Educational
-        Foundation and mentored dozens of student teams. Outside the lab I enjoy
-        hiking and supporting community STEM outreach.</p>
+        Foundation, mentoring dozens of student teams. Outside the shop I enjoy
+        hiking &mdash; I've logged over 5,000 miles on long-distance trails &mdash;
+        and supporting community STEM outreach.</p>
       </div>
-      <div class="avatar"></div>
+      <img class="avatar" src="avatar.svg" alt="Avatar">
     </div>
   </main>
 
   <footer>
-    © 2025 Sam Carter — more info coming soon
+    © 2025 Sam Carter
   </footer>
 </body>
 </html>

--- a/docs/avatar.svg
+++ b/docs/avatar.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <circle cx="60" cy="60" r="60" fill="#1e40af"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="60" fill="#fff" font-family="Arial">S</text>
+</svg>

--- a/docs/cube.js
+++ b/docs/cube.js
@@ -111,6 +111,8 @@ function queueMove(face, inverse=false) {
 }
 
 function scramble() {
+  if (animating) return;
+  resetCube();
   const moves = ['U','D','F','B','L','R'];
   for (let i=0;i<20;i++) {
     const face = moves[Math.floor(Math.random()*moves.length)];

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
     <h2 id="typewriter"></h2>
   </header>
   <main>
-    <p>Lab tech and robotics instructor.</p>
+    <p>Machine technician and robotics instructor.</p>
     <p>Specializes in 3D printing and hands-on STEM education.</p>
     <p>Currently exploring <strong>AI</strong> research at <strong>MiraCosta College</strong>.</p>
     <div id="scene"><div id="cube"></div></div>

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -24,19 +24,25 @@
     <div class="projects">
       <div class="card">
         <h2>3D Printing Operations</h2>
-        <p>Oversaw SLA, PolyJet, and FDM printers at GKN Additive to produce custom
-        parts and prototypes.</p>
+        <p>Oversaw SLA, PolyJet, and FDM printers at GKN Additive to produce custom parts and prototypes.</p>
       </div>
       <div class="card">
         <h2>Robotics Mentorship</h2>
-        <p>Developed curriculum and mentored more than 50 middle school teams
-        through the Carlsbad Educational Foundation.</p>
+        <p>Developed curriculum and mentored more than 50 middle school teams through the Carlsbad Educational Foundation.</p>
+      </div>
+      <div class="card">
+        <h2>CAD Automation Scripts</h2>
+        <p>Created parametric modeling tools to speed up part design and revision control.</p>
+      </div>
+      <div class="card">
+        <h2>Open Source AI Experiments</h2>
+        <p>Built small neural net demos while pursuing an AI certificate.</p>
       </div>
     </div>
   </main>
 
   <footer>
-    © 2025 Sam Carter — projects coming soon
+    © 2025 Sam Carter
   </footer>
 </body>
 </html>

--- a/docs/resume.html
+++ b/docs/resume.html
@@ -18,16 +18,24 @@
     <section>
       <h2>Experience</h2>
       <ul>
-        <li>3D Printing Technician, GKN Additive</li>
-        <li>Robotics Instructor, CEF</li>
+        <li><strong>2023&ndash;Present</strong> &mdash; Machine Technician, GKN Additive</li>
+        <li><strong>2021&ndash;2023</strong> &mdash; Robotics Instructor, Carlsbad Educational Foundation</li>
+        <li><strong>2018&ndash;2020</strong> &mdash; Hiked over 5,000 miles with no tent or sleeping bag</li>
       </ul>
     </section>
     <section>
       <h2>Education</h2>
-      <p>Coursework in mechanical engineering and AI, MiraCosta College</p>
+      <ul>
+        <li>AI Certificate, MiraCosta College</li>
+        <li>Associate's Degree in Artificial Intelligence (in progress)</li>
+        <li>Coursework in mechanical engineering</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Skills</h2>
+      <p>CAD modeling, programming, and electronics troubleshooting</p>
     </section>
   </main>
   <footer>© 2025 Sam Carter</footer>
-  <p style="text-align:center;color:#bbb;">Full resume coming soon.</p>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -13,7 +13,7 @@
 :root {
   --primary: #1a1a2e;
   --navy: #16213e;
-  --accent: #f472b6;
+  --accent: #38bdf8;
   --accent2: #60a5fa;
 }
 
@@ -21,7 +21,7 @@ body {
   margin: 0;
   font-family: 'IBM Plex Sans', sans-serif;
   line-height: 1.6;
-  background: linear-gradient(45deg, #1e3a8a, #9333ea, #ec4899, #14b8a6);
+  background: linear-gradient(45deg, #1e3a8a, #9333ea, #06b6d4, #14b8a6);
   background-size: 400% 400%;
   color: #eee;
   animation: gradient 20s ease infinite;
@@ -89,7 +89,7 @@ h2 {
   height: 120px;
   margin: 0 auto 1.5rem auto;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent), var(--accent2));
+  display: block;
   transition: transform 0.6s ease;
 }
 


### PR DESCRIPTION
## Summary
- tweak about page copy and avatar
- extend resume with yearly timeline
- expand projects list
- update home page text
- avoid pink in site gradient
- refine cube scramble and add placeholder avatar

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688667c9e5e083338982dac0e32ff357