### PR TITLE
Fix Jekyll front matter and adjust background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,6 @@
+---
+layout: none
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -5,7 +8,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Samuel P Carter - Bitcoin Journey</title>
     <style>
-        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: auto; }
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            padding: 20px;
+            max-width: 800px;
+            margin: auto;
+            background-color: #f5f5f5;
+            color: #333;
+        }
     </style>
 </head>
 <body>

--- a/notes.html
+++ b/notes.html
@@ -1,3 +1,6 @@
+---
+layout: none
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -5,7 +8,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Private Notes</title>
     <style>
-        body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; max-width: 800px; margin: auto; }
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            padding: 20px;
+            max-width: 800px;
+            margin: auto;
+            background-color: #f5f5f5;
+            color: #333;
+        }
         textarea { width: 100%; height: 400px; }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- fix Jekyll front matter so pages build
- set a neutral background color for index and notes pages

## Testing
- `python3 -m py_compile bullet_notes.py`

------
https://chatgpt.com/codex/tasks/task_b_6888371f74fc8333bae57417d3736f8d