### PR TITLE
Add keyboard shortcuts and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 The site has been simplified to a single page showing an interactive Rubik's Cube.
 Open `docs/index.html` in a browser to play with the cube. Use the scramble and reset
-buttons or rotate it with your mouse or keyboard. The cube has been restyled with
-larger tiles and a brighter color scheme for improved visibility.
+buttons or rotate it with your mouse or keyboard. Arrow keys rotate the entire cube,
+while the U, D, F, B, L, R keys perform face turns. Press `S` to scramble and `X` to
+reset. The cube has been restyled with larger tiles and a brighter color scheme for
+improved visibility.

--- a/docs/cube.css
+++ b/docs/cube.css
@@ -57,6 +57,14 @@
   background: #333;
 }
 
+.instructions {
+  text-align: center;
+  color: #ccc;
+  font-size: 0.9rem;
+  max-width: 260px;
+  margin: 0 auto;
+}
+
 #cube.dragging {
   cursor: grabbing;
 }

--- a/docs/cube.js
+++ b/docs/cube.js
@@ -322,6 +322,8 @@ document.addEventListener('keydown', e => {
     case 'B': return queueMove('B');
     case 'L': return queueMove('L');
     case 'R': return queueMove('R');
+    case 'S': return scramble();
+    case 'X': return resetCube();
     default: return;
   }
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,10 @@
     <button id="scramble-btn">Scramble</button>
     <button id="reset-btn">Reset</button>
   </div>
+  <p class="instructions">
+    Use arrow keys to rotate the cube and U, D, F, B, L, R keys for face turns.
+    Press S to scramble and X to reset.
+  </p>
   <script src="cube.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Support `S` and `X` keyboard shortcuts for scrambling and resetting
- Explain keyboard controls directly in the page and README

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `npm run lint` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_b_688ee5a483f4833383ebc276d97f0d3a